### PR TITLE
DockerCompose change ApiService + MySQL. PHP delete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,21 @@
 version: "3.7"
+
 services:
   api_service:
-    # Este servicio se construye a partir de la imagen Docker actual en el directorio de trabajo (indicado por el punto .).
     build: .
-    # Aseguramos reinicio del sistema si se detine
     restart: always
-    # Puertos externo:interno
     ports:
       - 8080:8080
-    # Variables de entorno utilizadas
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql_db:3306/gaticketdb
       SPRING_DATASOURCE_USERNAME: myuser
       SPRING_DATASOURCE_PASSWORD: mypass
-    # Se cargará despues de ....
     depends_on:
       - mysql_db
-    # Red interna
     networks:
       - mynetwork
-    # Comando al iniciar el contenedor
     command: sh -c './wait-for mysql_db:3306 -- mvn spring-boot:run'
+
   mysql_db:
     image: "mysql:8.0"
     restart: always
@@ -33,21 +28,9 @@ services:
       MYSQL_ROOT_PASSWORD: root
     networks:
       - mynetwork
-    # Para persistencia de los datos, generamos un volumen en el host
     volumes:
       - /Users/JSenen/IdeaProjects/gaticket/sql:/var/lib/mysql
-
-  apache_php:
-    image: php:apache
-    ports:
-      - "80:80"
-    volumes:
-      - /Applications/MAMP/htdocs/GaticketWeb:/var/www/html/GaticketWeb
-    networks:
-      - mynetwork
-
 
 networks:
   mynetwork:
     driver: bridge
-

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-crypto</artifactId>
 		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/juansenen/gaticket/domain/WebConfig.java
+++ b/src/main/java/com/juansenen/gaticket/domain/WebConfig.java
@@ -1,0 +1,13 @@
+package com.juansenen.gaticket.domain;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("http://localhost:8081");
+    }
+}


### PR DESCRIPTION
Change DockerCompose. Only Api-Service + MySql because with  apache:php don't work.
```
version: "3.7"
services:
  api_service:
    # Este servicio se construye a partir de la imagen Docker actual en el directorio de trabajo (indicado por el punto .).
    build: .
    # Aseguramos reinicio del sistema si se detine
    restart: always
    # Puertos externo:interno
    ports:
      - 8080:8080
    # Variables de entorno utilizadas
    environment:
      SPRING_DATASOURCE_URL: jdbc:mysql://mysql_db:3306/gaticketdb
      SPRING_DATASOURCE_USERNAME: myuser
      SPRING_DATASOURCE_PASSWORD: mypass
    # Se cargará despues de ....
    depends_on:
      - mysql_db
    # Red interna
    networks:
      - mynetwork
    # Comando al iniciar el contenedor
    command: sh -c './wait-for mysql_db:3306 -- mvn spring-boot:run'
  mysql_db:
    image: "mysql:8.0"
    restart: always
    ports:
      - 3306:3306
    environment:
      MYSQL_DATABASE: gaticketdb
      MYSQL_USER: myuser
      MYSQL_PASSWORD: mypass
      MYSQL_ROOT_PASSWORD: root
    networks:
      - mynetwork
    # Para persistencia de los datos, generamos un volumen en el host
    volumes:
      - /Users/JSenen/IdeaProjects/gaticket/sql:/var/lib/mysql

  apache_php:
    image: php:apache
    ports:
      - "80:80"
    volumes:
      - /Applications/MAMP/htdocs/GaticketWeb:/var/www/html/GaticketWeb
    networks:
      - mynetwork


networks:
  mynetwork:
    driver: bridge

```